### PR TITLE
[BUGFIX] Fix unparseable jQuery TypoScript conditions on TYPO3 v12+

### DIFF
--- a/Configuration/Sets/NsFaq/setup.typoscript
+++ b/Configuration/Sets/NsFaq/setup.typoscript
@@ -26,15 +26,6 @@ plugin.tx_nsfaq_faq {
 }
 
 
-[globalVar = LIT:1 = {$nsFaq.includeJquery}]
-page {
-    includeJSFooterlibs {
-        nsfaqJQuery = EXT:ns_faq/Resources/Public/JavaScript/frontend/jquery-3.4.1.min.js
-    }
-}
-[global]
-
-#Condition for the TYPO3 10 versions
 [{$nsFaq.includeJquery} == 1]
 page {
     includeJS {

--- a/Configuration/TypoScript/basicSettings_constants.typoscript
+++ b/Configuration/TypoScript/basicSettings_constants.typoscript
@@ -20,7 +20,7 @@ plugin.tx_nsfaq_faq {
     basicSettings {
         general {
             # cat=Ns_Faq_BasicSettings/03_Gen/04; type=boolean; label=LLL:EXT:ns_faq/Resources/Private/Language/locallang.xlf:tx_ns_faq.includejs
-            includeJquery =
+            includeJquery = 0
             
             # cat=Ns_Faq_BasicSettings/03_Gen/05; type=textarea; label=LLL:EXT:ns_faq/Resources/Private/Language/locallang.xlf:customCSS
             customCSS =

--- a/Configuration/TypoScript/setup.typoscript
+++ b/Configuration/TypoScript/setup.typoscript
@@ -54,15 +54,6 @@ page {
 }
 
 
-[globalVar = LIT:1 = {$plugin.tx_nsfaq_faq.basicSettings.general.includeJquery}]
-page {
-    includeJS {
-        JQuery = EXT:ns_faq/Resources/Public/JavaScript/frontend/jquery-3.4.1.min.js
-    }
-}
-[global]
-
-#Condition for the TYPO3 10 versions
 [{$plugin.tx_nsfaq_faq.basicSettings.general.includeJquery} == 1]
 page {
     includeJS {


### PR DESCRIPTION
## Problem

`Configuration/TypoScript/setup.typoscript` and `Configuration/Sets/NsFaq/setup.typoscript` each ship two conditions to optionally load jQuery:

```typoscript
[globalVar = LIT:1 = {$...includeJquery}]
...
[{$...includeJquery} == 1]
```

Since TYPO3 v12, frontend conditions are evaluated by the Symfony ExpressionLanguage. The first condition uses the old TYPO3 v9 `globalVar = LIT` syntax, which the parser cannot read. On every frontend request that (re)builds the TypoScript include tree, TYPO3 logs:

```
TYPO3 [ERROR] TypoScript condition [globalVar = LIT:1 = {$plugin.tx_nsfaq_faq.basicSettings.general.includeJquery}] could not be parsed:
SyntaxError: Unexpected character "=" around position 10
```

On a production site this fills the web server error log with hundreds of entries per hour.

The legacy `includeJquery` constant is additionally defined empty (`includeJquery =`). When the constant is empty, the second condition also becomes unparseable, resolving to ` == 1`:

```
TYPO3 [ERROR] TypoScript condition [{$plugin.tx_nsfaq_faq.basicSettings.general.includeJquery} == 1] could not be parsed:
SyntaxError: Unexpected character "$" around position 1
```

## Fix

- Remove the redundant legacy `[globalVar = LIT:1 = ...]` condition in both the legacy TypoScript and the site set. It is functionally identical to the modern `[{$...includeJquery} == 1]` condition, which is kept.
- Give the legacy `includeJquery` constant a default of `0`, so the remaining condition resolves to `0 == 1`. The site set already declares `default: false` for `nsFaq.includeJquery`, so only the legacy constants needed this.

Enabling `includeJquery` still loads jQuery exactly as before, so there is no behavior change for existing users.

## Verification

Reproduced on a TYPO3 13.4 site: every uncached TypoScript build logs both conditions as unparseable expressions (the exact errors shown above). Removing the `globalVar = LIT` line eliminates its parser error directly, and giving the constant a numeric default makes the remaining `{$...} == 1` condition resolve to a valid expression, as documented for [constants in conditions](https://docs.typo3.org/m/typo3/reference-typoscript/13.4/en-us/Syntax/Conditions/Index.html) (constants are replaced with their values before the expression language evaluates them).
